### PR TITLE
Add a reset zoom and UI to 100% key

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ You can increase zoom level with ``, (comma)`` and decrease it with ``. (period)
 
 By holding ``Left Shift`` or ``Right Shift`` and using the controls above, you can change the UI Scale.
 
+Press ``Home`` to reset both values to 100%.
+
 If you use a controller, you can also adjust it by pressing the ``left stick`` to decrease the zoom and ``right stick`` to increases the zoom.
 By holding ``Left Trigger & Right Trigger`` and using the controls above, you can change the UI Scale.
 
@@ -20,6 +22,7 @@ In the mod folder open the file ``config.json``:
   - "IncreaseZoomOrUI": the keys that increases the Zoom or UI
   - "DecreaseZoomOrUI": the key that decreases the zoom or UI
   - "HoldToChangeUIKeys": the key that you need to hold to change the UI instead of the zoom
+  - "ResetZoomAndUI": the key that resets both zoom and UI to 100%
   - "SuppressControllerButton": when set to "true" it only changes the zoom level with the controller button and "false" to let the game also handle the button press
   - "ZoomLevelIncreaseValue": How much to increase the zoom level (needs to be a positive number)
   - "ZoomLevelDecreaseValue": How much to decrease the zoom level (needs to be a negative number)

--- a/ZoomLevel/ModConfig.cs
+++ b/ZoomLevel/ModConfig.cs
@@ -13,6 +13,7 @@ namespace ZoomLevel
         public KeybindList IncreaseZoomOrUI { get; set; } = KeybindList.Parse("OemPeriod, RightStick");
         public KeybindList DecreaseZoomOrUI { get; set; } = KeybindList.Parse("OemComma, LeftStick");
         public KeybindList HoldToChangeUIKeys { get; set; } = KeybindList.Parse("LeftShift, RightShift, LeftTrigger + RightTrigger");
+        public KeybindList ResetZoomAndUI { get; set; } = KeybindList.Parse("Home");
 
         public bool SuppressControllerButton { get; set; } = true;
         public bool ZoomAndUIControlEverywhere { get; set; } = false;

--- a/ZoomLevel/ModEntry.cs
+++ b/ZoomLevel/ModEntry.cs
@@ -33,6 +33,7 @@ namespace ZoomLevel
                 genericModConfigMenuAPI.RegisterSimpleOption(ModManifest, "Increase zoom or UI", "The keybind that increases the zoom or UI in-game.", () => modConfigs.IncreaseZoomOrUI, (KeybindList val) => modConfigs.IncreaseZoomOrUI = val);
                 genericModConfigMenuAPI.RegisterSimpleOption(ModManifest, "Decrease zoom or UI", "The keybind that decreases the zoom or UI in-game.", () => modConfigs.DecreaseZoomOrUI, (KeybindList val) => modConfigs.DecreaseZoomOrUI = val);
                 genericModConfigMenuAPI.RegisterSimpleOption(ModManifest, "Hold to change UI", "The keybind that you hold to change UI instead of the zoom.", () => modConfigs.HoldToChangeUIKeys, (KeybindList val) => modConfigs.HoldToChangeUIKeys = val);
+                genericModConfigMenuAPI.RegisterSimpleOption(ModManifest, "Reset zoom and UI", "The keybind that resets both zoom and UI to 100%.", () => modConfigs.ResetZoomAndUI, (KeybindList val) => modConfigs.ResetZoomAndUI = val);
 
                 genericModConfigMenuAPI.RegisterSimpleOption(ModManifest, "Suppress controller button", "If your inputs are supressed or not.", () => modConfigs.SuppressControllerButton, (bool val) => modConfigs.SuppressControllerButton = val);
                 genericModConfigMenuAPI.RegisterSimpleOption(ModManifest, "Zoom and UI anywhere", "If activated you can control your zoom and UI level anywhere.", () => modConfigs.ZoomAndUIControlEverywhere, (bool val) => modConfigs.ZoomAndUIControlEverywhere = val);
@@ -71,6 +72,11 @@ namespace ZoomLevel
             else if (modConfigs.DecreaseZoomOrUI.JustPressed())
             {
                 ChangeZoomLevel(modConfigs.ZoomLevelDecreaseValue);
+                wasThePreviousButtonPressSucessfull = true;
+            }
+            else if (modConfigs.ResetZoomAndUI.JustPressed())
+            {
+                ResetZoomAndUI();
                 wasThePreviousButtonPressSucessfull = true;
             }
 
@@ -138,6 +144,21 @@ namespace ZoomLevel
                 Game1.options.localCoopDesiredUIScale = Game1.options.localCoopDesiredUIScale <= modConfigs.MaxZoomOutLevelAndUIValue ? modConfigs.MaxZoomOutLevelAndUIValue : Game1.options.localCoopDesiredUIScale;
             }
 
+            Program.gamePtr.refreshWindowSettings();
+        }
+
+        private void ResetZoomAndUI()
+        {
+            if (!Context.IsSplitScreen)
+            {
+                Game1.options.singlePlayerBaseZoomLevel = 1.0f;
+                Game1.options.singlePlayerDesiredUIScale = 1.0f;
+            }
+            else
+            {
+                Game1.options.localCoopBaseZoomLevel = 1.0f;
+                Game1.options.localCoopDesiredUIScale = 1.0f;
+            }
             Program.gamePtr.refreshWindowSettings();
         }
     }


### PR DESCRIPTION
Since some plugin UIs don't work well when zoomed, especially if UI zoom ≠ game zoom, a button to quickly reset both to 100% may be useful. Split screen is untested, I just copied the code…