### PR TITLE
Fix: Wrong keyboard shortcut for "Zoom Level" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Description and Features <!-- omit in toc -->
+## Description and Features
 
 **ZoomLevel** is a [Stardew Valley](http://stardewvalley.net/) mod based on [this mod](https://github.com/GuiNoya/SVMods/) and it allows you to change and adjust both the zoom level and UI Scale levels of the game. It works in single-player, local co-op and multiplayer.
 
@@ -13,8 +13,10 @@
 > [!NOTE]
 > Keep in mind that the only way to go beyond the default zoom levels is through the custom keybinds mentioned above. Trying to increase the zoom levels through the "normal" in-game settings won't work.
 
-## Contents <!-- omit in toc -->
+## Contents
 
+- [Description and Features](#description-and-features)
+- [Contents](#contents)
 - [Installation](#installation)
 - [Console Commands](#console-commands)
   - [In-game settings](#in-game-settings)

--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
-## Description and Features
+## Description and Features <!-- omit in toc -->
 
-**ZoomLevel** is a [Stardew Valley](http://stardewvalley.net/) mod based on [this mod](https://github.com/GuiNoya/SVMods/) and it allows you to change and adjust the zoom level and UI levels of the game.
+**ZoomLevel** is a [Stardew Valley](http://stardewvalley.net/) mod based on [this mod](https://github.com/GuiNoya/SVMods/) and it allows you to change and adjust both the zoom level and UI Scale levels of the game. It works in single-player, local co-op and multiplayer.
 
-- You can increase zoom level with `, (comma)` and decrease it with `. (period)`.<br>
-  By holding `Left Shift` or `Right Shift` and using the controls above, you can change the UI Scale.
+### Changing the "Zoom level" <!-- omit in toc -->
+- **Keyboard:** Increase with `. (period)`, decrease with `, (comma)`.
+- **Controller:** Increase by pressing `right stick`, decrease by pressing `left stick`.
 
-- If you use a controller, you can also adjust it by pressing the `left stick` to decrease the zoom and `right stick` to increases the zoom.<br>
-  By holding `Left Trigger & Right Trigger` and using the controls above, you can change the UI Scale.
+### Changing the "UI Scale" <!-- omit in toc -->
+- **Keyboard:** Hold `Left Shift` or `Right Shift`, and then use `. (period)` to increase, or `, (comma)` to decrease.
+- **Controller:** Hold `Left Trigger & Right Trigger` at the same time, and then use `right stick` to increase, or `left stick` to decrease.
 
-## Contents
+> [!NOTE]
+> Keep in mind that the only way to go beyond the default zoom levels is through the custom keybinds mentioned above. Trying to increase the zoom levels through the "normal" in-game settings won't work.
 
-- [Description and Features](#description-and-features)
-- [Contents](#contents)
+## Contents <!-- omit in toc -->
+
 - [Installation](#installation)
 - [Console Commands](#console-commands)
   - [In-game settings](#in-game-settings)


### PR DESCRIPTION
## Changes

- Fix: Wrong keyboard shortcut for "Zoom Level" in `README.md`
- Update: Organize `README.md` features
- Add: Note about not being able to go beyond default zoom levels through the in-game's settings menu

## Notes

- I noticed that the `README.md` had the increase and decrease keyboard shortcuts swapped, so I took the chance and corrected that.
- My main goal of this PR is actually to attempt to make it even more "straighforward" on how to use the mod and what to expect of it.
    - I decided to organize it by "zoom type" instead of "controller type", as I think it makes it easier to find what one wants: either the "Zoom level" or the "UI Scale" zoom.
    - I've also removed the "Description and Features" and "Contents" from the table of contents, as I think it doesn't make sense to show topics in a table of contents that are "above" it.
    - I've also added a note regarding one of the things that confused me the most with this mod: I was expecting to go into the game settings and simply increase the values beyond their default limits, but that didn't work. Instead, one must use the custom keybinds. I believe this to be crucial information, that should be part of the `README.md`!
    - Obviously, (some of) these changes are personal preference in a way, so feel free to alter them to your liking. I suppose the only "important" part of this is the "keybind fix", as that was wrong information.

## Linkage

- Relates to #26